### PR TITLE
Helps 4373 npx tool redesign

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,20 @@ import * as prompts from 'prompts';
 import * as Sqrl from 'squirrelly';
 import * as ua from 'universal-analytics';
 import { default as templates } from '@oliveai/loop-templates';
-import { TemplatesObject, TemplateFile } from '@oliveai/loop-templates/dist/types';
+import {
+  TemplatesObject,
+  TemplateFile,
+} from '@oliveai/loop-templates/dist/types';
 
-const analytics = __GOOGLE_ANALYTICS_ID__ ? 
-  ua(__GOOGLE_ANALYTICS_ID__) : 
-  // For development
-  {
-    event: () => ({
-        send: () => undefined
+const analytics = __GOOGLE_ANALYTICS_ID__
+  ? ua(__GOOGLE_ANALYTICS_ID__)
+  : // For development
+    {
+      event: () => ({
+        send: () => undefined,
       }),
-    set: () => undefined,
-  };
+      set: () => undefined,
+    };
 
 const osName = platform === 'win32' ? 'windows' : platform;
 
@@ -27,9 +30,9 @@ analytics.set('cd1', __ENVIRONMENT__);
 analytics.set('cd4', osName);
 
 type ProjectOptions = {
-  name: string,
-  language: string,
-  aptitudes: TemplateFile['aptitude'][]
+  name: string;
+  language: string;
+  aptitudes: TemplateFile['aptitude'][];
 };
 
 const projectOptions: ProjectOptions = {
@@ -61,7 +64,7 @@ const createProject = async () => {
     const renderTemplate = async (template: string, filePath: string) => {
       const fileContents = await Sqrl.render(template, {
         isTypeScript,
-        hasConfigAptitude: projectAptitudes.includes("config"),
+        hasConfigAptitude: projectAptitudes.includes('config'),
         projectName,
         aptitudes: projectAptitudes,
         promiseVoid: ': Promise<void>',
@@ -81,7 +84,10 @@ const createProject = async () => {
       return filename;
     };
 
-    const renderFileMap = async (templatesObject: TemplatesObject, targetFilePath: string) => {
+    const renderFileMap = async (
+      templatesObject: TemplatesObject,
+      targetFilePath: string
+    ) => {
       const { fileMap } = templatesObject;
       if (!fileMap) {
         return console.error('There is no file map on this object');
@@ -96,8 +102,9 @@ const createProject = async () => {
           aptitude !== 'any' &&
           !projectAptitudes.includes(aptitude) &&
           !nonzero
-        )
-          {continue;}
+        ) {
+          continue;
+        }
 
         // If it's a string, it's a template. Otherwise, it's a directory/object.
         if (typeof templatesObject[key] === 'string') {
@@ -110,7 +117,10 @@ const createProject = async () => {
           const newTargetFilePath = path.join(targetFilePath, key);
           await fs.mkdir(newTargetFilePath);
 
-          await renderFileMap(templatesObject[key] as TemplatesObject, newTargetFilePath);
+          await renderFileMap(
+            templatesObject[key] as TemplatesObject,
+            newTargetFilePath
+          );
         }
       }
     };
@@ -120,14 +130,16 @@ const createProject = async () => {
     await fs.mkdir(targetBasePath);
 
     await renderFileMap(templates, targetBasePath);
-    
+
     try {
-      analytics.event({
-        eventCategory: 'Loop Authors',
-        eventAction: 'Loop Source Code Generated: NPX',
-        eventLabel: 'Loop Created',
-      }).send();
-    } catch (error) {};
+      analytics
+        .event({
+          eventCategory: 'Loop Authors',
+          eventAction: 'Loop Source Code Generated: NPX',
+          eventLabel: 'Loop Created',
+        })
+        .send();
+    } catch (error) {}
 
     installNodeModules();
   } catch (error) {
@@ -149,11 +161,13 @@ const languagePrompt = () => {
     projectOptions.language = language;
 
     try {
-      analytics.event({
-        eventCategory: 'Loop Authors',
-        eventAction: 'Loop Source Code Generated: NPX',
-        eventLabel: `Language Selected: ${language}`,
-      }).send();
+      analytics
+        .event({
+          eventCategory: 'Loop Authors',
+          eventAction: 'Loop Source Code Generated: NPX',
+          eventLabel: `Language Selected: ${language}`,
+        })
+        .send();
     } catch (error) {}
 
     return createProject();
@@ -166,34 +180,107 @@ const aptitudesPrompt = () => {
     name: 'aptitudes',
     message: 'Which Aptitudes do you want to include?',
     choices: [
-      { title: 'Browser', value: 'browser' },
-      { title: 'Clipboard', value: 'clipboard' },
-      { title: 'Cursor', value: 'cursor' },
-      { title: 'Config', value: 'config' },
-      { title: 'Document', value: 'document' },
-      { title: 'Filesystem', value: 'filesystem' },
-      { title: 'Keyboard', value: 'keyboard' },
-      { title: 'Network', value: 'network' },
-      { title: 'Process', value: 'process' },
-      { title: 'Search', value: 'search' },
-      { title: 'System', value: 'system'},
-      { title: 'UI', value: 'ui' },
-      { title: 'User', value: 'user' },
-      { title: 'Vault', value: 'vault' },
-      { title: 'Window', value: 'window' },
+      {
+        title: 'Browser',
+        value: 'browser',
+        description:
+          'This Aptitude, combined with the Olive Helps browser extension, allows an author to interact with your browser.',
+      },
+      {
+        title: 'Clipboard',
+        value: 'clipboard',
+        description:
+          'The Clipboard Aptitude provides the ability to interact with your clipboard on your system.',
+      },
+      {
+        title: 'Config',
+        value: 'config',
+        description:
+          'The Config Aptitude is an optional Aptitude that a Loop Developer may implement in order to allow org admins to define loop properties designated by a loop author to be configurable.',
+      },
+      {
+        title: 'Cursor',
+        value: 'cursor',
+        description:
+          'The Cursor Aptitude provides the ability to retrieve information about the user\'s cursor.',
+      },
+      {
+        title: 'Document',
+        value: 'document',
+        description:
+          'The Document Aptitude provides the ability to interact with documents (currently only XLSX files).',
+      },
+      {
+        title: 'Filesystem',
+        value: 'filesystem',
+        description:
+          'The Filesystem Aptitude provides the ability to interact with files on the system (including things reading, writing, and deleting).',
+      },
+      {
+        title: 'Keyboard',
+        value: 'keyboard',
+        description:
+          'The Keyboard Aptitude provides access to the the ability to listen to hotkeys pressed and text or characters typed.',
+      },
+      {
+        title: 'Network',
+        value: 'network',
+        description:
+          'The Network aptitude provides the ability make HTTP requests, set up a web socket connection, and encode and decode Uint8Arrays.',
+      },
+      {
+        title: 'Process',
+        value: 'process',
+        description:
+          'The Process Aptitude provides the ability to examine attributes about processes running on the user\'s computer.',
+      },
+      {
+        title: 'Search',
+        value: 'search',
+        description:
+          'The Search Aptitude provides the ability to index a set of documents and search the data using query strings and fuzzy searching.',
+      },
+      {
+        title: 'System',
+        value: 'system',
+        description:
+          'The System Aptitude provides the ability to access information about the user\'s system.',
+      },
+      {
+        title: 'User',
+        value: 'user',
+        description:
+          'The User aptitude provides the ability to retrieve a JWT for the current user which can be used to identify an Olive Helps user to 3rd party services.',
+      },
+      {
+        title: 'Vault',
+        value: 'vault',
+        description:
+          'The Vault Aptitude provides the ability to read and write strings in either macOS\' Keychain or Window\'s Credential Manager, depending on the system.',
+      },
+      {
+        title: 'Window',
+        value: 'window',
+        description:
+          'The Window Aptitude provides the ability to obtain information about windows on a user\'s desktop (position, name, etc.) as well as listen to window events (gaining focus, losing focus, etc.).',
+      },
     ],
     hint: 'Use your spacebar to select. You can select multiple!',
   }).then((response) => {
+    // pushing in required aptitudes
+    response.aptitudes.push('whisper', 'ui');
     const { aptitudes }: { aptitudes: ProjectOptions['aptitudes'] } = response;
     projectOptions.aptitudes = aptitudes;
 
     aptitudes.forEach((aptitude) => {
       try {
-        analytics.event({
-          eventCategory: 'Loop Authors',
-          eventAction: 'Loop Source Code Generated: NPX',
-          eventLabel: `Aptitude Selected: ${aptitude}`,
-        }).send();
+        analytics
+          .event({
+            eventCategory: 'Loop Authors',
+            eventAction: 'Loop Source Code Generated: NPX',
+            eventLabel: `Aptitude Selected: ${aptitude}`,
+          })
+          .send();
       } catch (error) {}
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,20 +9,17 @@ import * as prompts from 'prompts';
 import * as Sqrl from 'squirrelly';
 import * as ua from 'universal-analytics';
 import { default as templates } from '@oliveai/loop-templates';
-import {
-  TemplatesObject,
-  TemplateFile,
-} from '@oliveai/loop-templates/dist/types';
+import { TemplatesObject, TemplateFile } from '@oliveai/loop-templates/dist/types';
 
-const analytics = __GOOGLE_ANALYTICS_ID__
-  ? ua(__GOOGLE_ANALYTICS_ID__)
-  : // For development
-    {
-      event: () => ({
-        send: () => undefined,
+const analytics = __GOOGLE_ANALYTICS_ID__ ? 
+  ua(__GOOGLE_ANALYTICS_ID__) : 
+  // For development
+  {
+    event: () => ({
+        send: () => undefined
       }),
-      set: () => undefined,
-    };
+    set: () => undefined,
+  };
 
 const osName = platform === 'win32' ? 'windows' : platform;
 
@@ -30,9 +27,9 @@ analytics.set('cd1', __ENVIRONMENT__);
 analytics.set('cd4', osName);
 
 type ProjectOptions = {
-  name: string;
-  language: string;
-  aptitudes: TemplateFile['aptitude'][];
+  name: string,
+  language: string,
+  aptitudes: TemplateFile['aptitude'][]
 };
 
 const projectOptions: ProjectOptions = {
@@ -84,10 +81,7 @@ const createProject = async () => {
       return filename;
     };
 
-    const renderFileMap = async (
-      templatesObject: TemplatesObject,
-      targetFilePath: string
-    ) => {
+    const renderFileMap = async (templatesObject: TemplatesObject, targetFilePath: string) => {
       const { fileMap } = templatesObject;
       if (!fileMap) {
         return console.error('There is no file map on this object');
@@ -102,9 +96,8 @@ const createProject = async () => {
           aptitude !== 'any' &&
           !projectAptitudes.includes(aptitude) &&
           !nonzero
-        ) {
-          continue;
-        }
+        )
+          {continue;}
 
         // If it's a string, it's a template. Otherwise, it's a directory/object.
         if (typeof templatesObject[key] === 'string') {
@@ -117,10 +110,7 @@ const createProject = async () => {
           const newTargetFilePath = path.join(targetFilePath, key);
           await fs.mkdir(newTargetFilePath);
 
-          await renderFileMap(
-            templatesObject[key] as TemplatesObject,
-            newTargetFilePath
-          );
+          await renderFileMap(templatesObject[key] as TemplatesObject, newTargetFilePath);
         }
       }
     };
@@ -130,16 +120,14 @@ const createProject = async () => {
     await fs.mkdir(targetBasePath);
 
     await renderFileMap(templates, targetBasePath);
-
+    
     try {
-      analytics
-        .event({
-          eventCategory: 'Loop Authors',
-          eventAction: 'Loop Source Code Generated: NPX',
-          eventLabel: 'Loop Created',
-        })
-        .send();
-    } catch (error) {}
+      analytics.event({
+        eventCategory: 'Loop Authors',
+        eventAction: 'Loop Source Code Generated: NPX',
+        eventLabel: 'Loop Created',
+      }).send();
+    } catch (error) {};
 
     installNodeModules();
   } catch (error) {
@@ -161,13 +149,11 @@ const languagePrompt = () => {
     projectOptions.language = language;
 
     try {
-      analytics
-        .event({
-          eventCategory: 'Loop Authors',
-          eventAction: 'Loop Source Code Generated: NPX',
-          eventLabel: `Language Selected: ${language}`,
-        })
-        .send();
+      analytics.event({
+        eventCategory: 'Loop Authors',
+        eventAction: 'Loop Source Code Generated: NPX',
+        eventLabel: `Language Selected: ${language}`,
+      }).send();
     } catch (error) {}
 
     return createProject();
@@ -274,13 +260,11 @@ const aptitudesPrompt = () => {
 
     aptitudes.forEach((aptitude) => {
       try {
-        analytics
-          .event({
-            eventCategory: 'Loop Authors',
-            eventAction: 'Loop Source Code Generated: NPX',
-            eventLabel: `Aptitude Selected: ${aptitude}`,
-          })
-          .send();
+        analytics.event({
+          eventCategory: 'Loop Authors',
+          eventAction: 'Loop Source Code Generated: NPX',
+          eventLabel: `Aptitude Selected: ${aptitude}`,
+        }).send();
       } catch (error) {}
     });
 


### PR DESCRIPTION
## [HELPS-4373](https://crosschx.atlassian.net/browse/HELPS-4373)

Acceptance Criteria
There should be a new help utility that lists all the aptitudes with their descriptions per: [https://docs.google.com/spreadsheets/d/1HnWKDB8q3FFKaH0HsIxbE8BsmhTBulDP4U7r8wiIi1s/edit?usp=sharing - Connect to preview](https://docs.google.com/spreadsheets/d/1HnWKDB8q3FFKaH0HsIxbE8BsmhTBulDP4U7r8wiIi1s/edit?usp=sharing) 

This utility should appear in a menu of all utilities (if we have one of those for NPX)

All Aptitudes should be listed to select to add to a new loop. Here are the new ones we added with this release:

Config

Search

System

Vault

Browser

Cursor

Document

The NPX tool should be pulling in the Whisper and UI aptitude in by default, and not be available to be unselected on creation
